### PR TITLE
Backport: Fix repository authentication with temporary credentials

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -765,7 +765,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 		return
 	}
 
-	createTimeout, diags := state.Timeouts.Create(ctx, 20*time.Minute)
+	createTimeout, diags := plan.Timeouts.Create(ctx, 20*time.Minute)
 	resp.Diagnostics.Append(diags...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -969,7 +969,7 @@ func (r *HelmRelease) Create(ctx context.Context, req resource.CreateRequest, re
 		}
 
 		// Save state to prevent orphaning the release from Terraform tracking
-		resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+		resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 
 		resp.Diagnostics.Append(diag.NewWarningDiagnostic("Helm release created with warnings", fmt.Sprintf("Helm release %q was created but has a failed status. Use the `helm` command to investigate the error, correct it, then run Terraform again.", client.ReleaseName)))
 		resp.Diagnostics.Append(diag.NewErrorDiagnostic("Helm release error", err.Error()))


### PR DESCRIPTION
## Summary

- Backport of upstream PR [hashicorp/terraform-provider-helm#1687](https://github.com/hashicorp/terraform-provider-helm/pull/1687)
- Fix repository authentication failure when using temporary credentials (e.g., AWS STS tokens, ECR tokens) during `helm_release` update operations

## Changes

- Use plan credentials instead of state credentials in `Update()` for OCI registry login
- Rename `state` variable to `plan` in `Create()` for consistency with Terraform Plugin Framework conventions

## Original Author

Cherry-picked from upstream with original author attribution preserved:
- Kevin Frommelt (@kevinfrommelt)

Closes #10