### PR TITLE
Backport: Fix keyring and other non-computed fields plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ State is compatible - no import required.
 
 - Fix: Preserve Terraform state on failed Helm operations ([#1669](https://github.com/hashicorp/terraform-provider-helm/issues/1669))
 - Fix: Nil pointer crash when updating OCI chart dependencies ([#1726](https://github.com/hashicorp/terraform-provider-helm/pull/1726))
+- Fix: 'Provider produced invalid plan' error on upgrade from v2.x ([#1695](https://github.com/hashicorp/terraform-provider-helm/issues/1695), [#1739](https://github.com/hashicorp/terraform-provider-helm/pull/1739))
 - Backport: Add StateUpdater for schema_version 0 ([#1741](https://github.com/hashicorp/terraform-provider-helm/pull/1741)) - Fixes upgrade path from provider versions < 2.17.0
 
 ## Roadmap

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -229,7 +229,7 @@ func (m suppressKeyringPlanModifier) MarkdownDescription(ctx context.Context) st
 func (m suppressKeyringPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
 	var verify types.Bool
 	req.Plan.GetAttribute(ctx, path.Root("verify"), &verify)
-	if !verify.IsNull() && !verify.ValueBool() {
+	if !verify.IsNull() && !verify.ValueBool() && req.ConfigValue.IsNull() {
 		resp.PlanValue = req.StateValue
 	}
 }

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -311,6 +311,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"devel": schema.BoolAttribute{
 				Optional:    true,
 				Computed:    true,
+				Default:     booldefault.StaticBool(false),
 				Description: "Use chart development versions, too. Equivalent to version '>0.0.0-0'. If 'version' is set, this is ignored",
 				PlanModifiers: []planmodifier.Bool{
 					suppressDevel(),
@@ -346,6 +347,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			"keyring": schema.StringAttribute{
 				Optional:    true,
 				Computed:    true,
+				Default:     stringdefault.StaticString(""),
 				Description: "Location of public keys used for verification, Used only if 'verify is true'",
 				PlanModifiers: []planmodifier.String{
 					suppressKeyring(),

--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -310,6 +310,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			},
 			"devel": schema.BoolAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Use chart development versions, too. Equivalent to version '>0.0.0-0'. If 'version' is set, this is ignored",
 				PlanModifiers: []planmodifier.Bool{
 					suppressDevel(),
@@ -344,6 +345,7 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 			},
 			"keyring": schema.StringAttribute{
 				Optional:    true,
+				Computed:    true,
 				Description: "Location of public keys used for verification, Used only if 'verify is true'",
 				PlanModifiers: []planmodifier.String{
 					suppressKeyring(),
@@ -591,7 +593,9 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 						},
 						"type": schema.StringAttribute{
 							Optional:  true,
+							Computed:  true,
 							WriteOnly: true,
+							Default:   stringdefault.StaticString(""),
 							Validators: []validator.String{
 								stringvalidator.OneOf("auto", "string"),
 							},
@@ -635,6 +639,8 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 						},
 						"type": schema.StringAttribute{
 							Optional: true,
+							Computed: true,
+							Default:  stringdefault.StaticString(""),
 							Validators: []validator.String{
 								stringvalidator.OneOf("auto", "string", "literal"),
 							},


### PR DESCRIPTION
## Summary

- Backports upstream PR [hashicorp/terraform-provider-helm#1739](https://github.com/hashicorp/terraform-provider-helm/pull/1739)
- Fixes issue where `keyring`, `devel`, and `set`/`set_sensitive` `type` fields cause invalid plan errors when migrating to Helm provider v3.0+

## Changes

- Add `Computed: true` to `devel` field
- Add `Computed: true` to `keyring` field  
- Add `Computed: true` and default value to `set_wo.type` field
- Add `Computed: true` and default value to `set_sensitive.type` field
- Fix `suppressKeyringPlanModifier` to only apply when config value is null

## Related Issues

- Closes #8
- Upstream: [hashicorp/terraform-provider-helm#1695](https://github.com/hashicorp/terraform-provider-helm/issues/1695)

## Test plan

- [ ] Verify plan no longer fails with "planned value for a non-computed attribute" error
- [ ] Existing tests pass