### PR TITLE
Fix: terraform plan failing with read-only credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ State is compatible - no import required.
 - Fix: Preserve Terraform state on failed Helm operations ([#1669](https://github.com/hashicorp/terraform-provider-helm/issues/1669))
 - Fix: Nil pointer crash when updating OCI chart dependencies ([#1726](https://github.com/hashicorp/terraform-provider-helm/pull/1726))
 - Backport: Add StateUpdater for schema_version 0 ([#1741](https://github.com/hashicorp/terraform-provider-helm/pull/1741)) - Fixes upgrade path from provider versions < 2.17.0
+- Fix: `terraform plan` failing with read-only credentials ([#1735](https://github.com/hashicorp/terraform-provider-helm/issues/1735)) - Falls back to client-side dry-run when server-side dry-run is forbidden
 
 ## Roadmap
 

--- a/docs/resources/release.md
+++ b/docs/resources/release.md
@@ -374,6 +374,24 @@ chart, which means that if there are any
 [statefulset](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) resources in the chart, they will
 be replaced, which will cause a rolling update of the pods.
 
+## Plan Behavior
+
+### Server-Side vs Client-Side Dry-Run
+
+During `terraform plan`, the provider performs a dry-run to validate the Helm release configuration. There are two modes:
+
+- **Server-Side Dry-Run (SSA)**: Sends the manifests to the Kubernetes API server for validation. Provides accurate validation including webhook checks and conflict detection. Requires write permissions.
+
+- **Client-Side Dry-Run (CSA)**: Validates manifests locally without contacting the API server. Less accurate but works with read-only credentials.
+
+The provider automatically falls back from SSA to CSA when permission errors occur.
+
+### Using Read-Only Credentials for Plan
+
+If you run `terraform plan` with read-only Kubernetes credentials (common in CI/CD pipelines), the provider will automatically use client-side dry-run. No additional configuration is required.
+
+-> **Note:** Some validation errors may only be detected during `terraform apply` when using client-side dry-run.
+
 ## Import
 
 A Helm Release resource can be imported using its namespace and name e.g.

--- a/helm/kube_resources.go
+++ b/helm/kube_resources.go
@@ -258,40 +258,6 @@ func getLiveResources(ctx context.Context, r *release.Release, m *Meta) (map[str
 	return cleaned, diags
 }
 
-func getDryRunResourcesClientSide(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
-	var diags diag.Diagnostics
-
-	actionConfig, err := m.GetHelmConfiguration(ctx, r.Namespace)
-	if err != nil {
-		diags.AddError("Helm Config Error", err.Error())
-		return nil, diags
-	}
-
-	rawResources, resDiags := mapResources(ctx, actionConfig, r, func(i *resource.Info) (runtime.Object, error) {
-		return i.Object, nil
-	})
-	diags.Append(resDiags...)
-	if resDiags.HasError() {
-		return rawResources, diags
-	}
-	cleaned := make(map[string]string, len(rawResources))
-	for k, v := range rawResources {
-		var obj map[string]any
-		if err := json.Unmarshal([]byte(v), &obj); err != nil {
-			cleaned[k] = v
-			continue
-		}
-		normalizeK8sObject(obj)
-		if b, err := json.Marshal(obj); err == nil {
-			cleaned[k] = string(b)
-		} else {
-			cleaned[k] = v
-		}
-	}
-
-	return cleaned, diags
-}
-
 func getDryRunResources(ctx context.Context, r *release.Release, m *Meta) (map[string]string, diag.Diagnostics) {
 	var diags diag.Diagnostics
 


### PR DESCRIPTION
## Summary

- Fix `terraform plan` failing with read-only Kubernetes credentials by falling back to client-side dry-run when server-side dry-run encounters permission errors
- Add documentation for plan behavior

## Background

### Problem

Since v3.1.0 (originally introduced in v2.17.0 via PR #1335), `terraform plan` fails with read-only credentials:

```
│ Error: Visit Error
│ 
│ serviceaccounts "xxx" is forbidden: User "read-only-role" cannot patch resource "serviceaccounts"
```

**Root cause**: The provider uses server-side apply (SSA) dry-run to validate manifests during plan. SSA dry-run sends actual patch requests to the Kubernetes API server, which performs permission checks even though no changes are persisted. This is Kubernetes behavior, not Helm's.

### Impact

Common CI/CD pattern is broken:
- PR creation: `terraform plan` with read-only credentials
- After merge: `terraform apply` with write credentials

With Helm v4 making SSA the default, this issue will become more prevalent.

## Design Decision

### Approach: Fallback Implementation

```
Plan flow:
1. Attempt SSA dry-run (accurate validation when write permissions exist)
2. On permission error → Fall back to CSA dry-run (works with read-only credentials)
3. Other errors → Return error as-is
```

### Why Fallback?

| Option | Evaluation |
|--------|-----------|
| Always use CSA during plan | ✗ Reduces validation accuracy when write permissions exist |
| **Fallback implementation** | ✓ Supports both use cases |
| Wait for Helm fix | ✗ SSA becomes default in Helm v4, won't be fixed |
| Wait for Kubernetes fix | ✗ SSA spec change is unrealistic |

### Validation Accuracy Comparison

| Validation | SSA dry-run | CSA dry-run |
|------------|-------------|-------------|
| Manifest syntax | ✓ | ✓ |
| Schema validation | ✓ (server-side) | △ (client-side) |
| Webhook validation | ✓ | ✗ |
| Conflict detection | ✓ | ✗ |
| CRD validation | ✓ | △ |

CSA fallback has lower validation accuracy, but issues will be caught during apply.

## Changes

Cherry-picked from upstream PR #1736:
- `730d51d4` - Fallback to local object when server-side apply fails
- `0b9726d4` - Remove outdated function

Additional:
- `1ec54fd6` - docs: Add plan behavior documentation

## Test Plan

- [x] All acceptance tests pass (Terraform 1.14.4, 6 parallel)

## References

- [Issue #1735: Patch operation during terraform plan](https://github.com/hashicorp/terraform-provider-helm/issues/1735)
- [PR #1736: Fallback to local object when server-side apply fails](https://github.com/hashicorp/terraform-provider-helm/pull/1736)
- [PR #1335: Server-side dry-run for chart lookups](https://github.com/hashicorp/terraform-provider-helm/pull/1335)