### PR TITLE
fix: keep keyring/devel stable on upgrade from provider v2.x

### DIFF
--- a/helm/resource_helm_release.go
+++ b/helm/resource_helm_release.go
@@ -196,7 +196,7 @@ func suppressDescription() planmodifier.String {
 type suppressDevelPlanModifier struct{}
 
 func (m suppressDevelPlanModifier) Description(ctx context.Context) string {
-	return "Suppress changes if the version is set"
+	return "When devel is not set in the config, keep the value from prior state instead of planning a new value."
 }
 
 func (m suppressDevelPlanModifier) MarkdownDescription(ctx context.Context) string {
@@ -204,9 +204,12 @@ func (m suppressDevelPlanModifier) MarkdownDescription(ctx context.Context) stri
 }
 
 func (m suppressDevelPlanModifier) PlanModifyBool(ctx context.Context, req planmodifier.BoolRequest, resp *planmodifier.BoolResponse) {
-	var version types.String
-	req.Plan.GetAttribute(ctx, path.Root("version"), &version)
-	if !version.IsNull() && version.ValueString() != "" && req.ConfigValue.IsNull() {
+	// devel is an optional input. It is declared Computed so that, when it is
+	// absent from the config, we can carry the prior state value forward
+	// without Terraform rejecting the plan ("planned value for a non-computed
+	// attribute"). Falling back to the prior state (null on create) always
+	// yields a known value, so the attribute never stays unknown after apply.
+	if req.ConfigValue.IsNull() {
 		resp.PlanValue = req.StateValue
 	}
 }
@@ -219,7 +222,7 @@ func suppressDevel() planmodifier.Bool {
 type suppressKeyringPlanModifier struct{}
 
 func (m suppressKeyringPlanModifier) Description(ctx context.Context) string {
-	return "Suppress changes if verify is false"
+	return "When keyring is not set in the config, keep the value from prior state instead of planning a new value."
 }
 
 func (m suppressKeyringPlanModifier) MarkdownDescription(ctx context.Context) string {
@@ -227,9 +230,13 @@ func (m suppressKeyringPlanModifier) MarkdownDescription(ctx context.Context) st
 }
 
 func (m suppressKeyringPlanModifier) PlanModifyString(ctx context.Context, req planmodifier.StringRequest, resp *planmodifier.StringResponse) {
-	var verify types.Bool
-	req.Plan.GetAttribute(ctx, path.Root("verify"), &verify)
-	if !verify.IsNull() && !verify.ValueBool() {
+	// keyring is an optional input. It is declared Computed so that, when it is
+	// absent from the config, we can carry the prior state value forward
+	// without Terraform rejecting the plan ("planned value for a non-computed
+	// attribute"). This is what allows upgrading from provider v2.x, whose
+	// state stored a non-null keyring, to plan cleanly. When the user does set
+	// keyring explicitly, the config value is always honored.
+	if req.ConfigValue.IsNull() {
 		resp.PlanValue = req.StateValue
 	}
 }
@@ -309,7 +316,11 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				},
 			},
 			"devel": schema.BoolAttribute{
-				Optional:    true,
+				Optional: true,
+				// Computed so the suppressDevel plan modifier can carry the
+				// prior-state value forward when devel is absent from the
+				// config (required for clean upgrades from provider v2.x).
+				Computed:    true,
 				Description: "Use chart development versions, too. Equivalent to version '>0.0.0-0'. If 'version' is set, this is ignored",
 				PlanModifiers: []planmodifier.Bool{
 					suppressDevel(),
@@ -343,7 +354,11 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 				Computed: true,
 			},
 			"keyring": schema.StringAttribute{
-				Optional:    true,
+				Optional: true,
+				// Computed so the suppressKeyring plan modifier can carry the
+				// prior-state value forward when keyring is absent from the
+				// config (required for clean upgrades from provider v2.x).
+				Computed:    true,
 				Description: "Location of public keys used for verification, Used only if 'verify is true'",
 				PlanModifiers: []planmodifier.String{
 					suppressKeyring(),
@@ -633,8 +648,13 @@ func (r *HelmRelease) Schema(ctx context.Context, req resource.SchemaRequest, re
 							Required:  true,
 							Sensitive: true,
 						},
+						// Computed + default "" mirrors the "set" block's type
+						// attribute so an omitted type plans consistently with
+						// stored state (required for clean upgrades from v2.x).
 						"type": schema.StringAttribute{
 							Optional: true,
+							Computed: true,
+							Default:  stringdefault.StaticString(""),
 							Validators: []validator.String{
 								stringvalidator.OneOf("auto", "string", "literal"),
 							},

--- a/helm/resource_helm_release_test.go
+++ b/helm/resource_helm_release_test.go
@@ -113,6 +113,44 @@ func TestAccResourceRelease_set_wo(t *testing.T) {
 	})
 }
 
+// TestAccResourceRelease_dropOptionalComputed reproduces the upgrade-from-v2.x
+// scenario from hashicorp/terraform-provider-helm#1695: a release whose prior
+// state carries non-null values for optional-but-suppressed attributes
+// (keyring, devel) must still plan cleanly once those attributes are removed
+// from the configuration. Before keyring/devel were made Computed, the suppress
+// plan modifiers wrote the prior-state value onto a non-computed attribute,
+// which Terraform rejects with "planned value ... for a non-computed attribute".
+func TestAccResourceRelease_dropOptionalComputed(t *testing.T) {
+	name := randName("dropoptional")
+	namespace := createRandomNamespace(t)
+	defer deleteNamespace(t, namespace)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: protoV6ProviderFactories(),
+		Steps: []resource.TestStep{
+			{
+				// keyring/devel are present in state, as they would be after a
+				// release created by the v2.x provider.
+				Config: testAccHelmReleaseConfigDropOptionalComputed(testResourceName, namespace, name, "1.2.3",
+					"keyring = \"/tmp/example.gpg\"\n\t\t\tdevel   = true"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "keyring", "/tmp/example.gpg"),
+					resource.TestCheckResourceAttr("helm_release.test", "devel", "true"),
+				),
+			},
+			{
+				// Removing them from the config must not error and must carry
+				// the prior values forward (suppressed change, empty plan).
+				Config: testAccHelmReleaseConfigDropOptionalComputed(testResourceName, namespace, name, "1.2.3", ""),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("helm_release.test", "keyring", "/tmp/example.gpg"),
+					resource.TestCheckResourceAttr("helm_release.test", "devel", "true"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceRelease_emptyVersion(t *testing.T) {
 	name := randName("basic")
 	namespace := createRandomNamespace(t)
@@ -1445,6 +1483,19 @@ func testAccHelmReleaseConfigBasic(resource, ns, name, version string) string {
 			]
 		}
 	`, resource, name, ns, testRepositoryURL, version)
+}
+
+func testAccHelmReleaseConfigDropOptionalComputed(resource, ns, name, version, extra string) string {
+	return fmt.Sprintf(`
+		resource "helm_release" "%s" {
+			name       = %q
+			namespace  = %q
+			repository = %q
+			chart      = "test-chart"
+			version    = %q
+			%s
+		}
+	`, resource, name, ns, testRepositoryURL, version, extra)
 }
 
 func testAccHelmReleaseConfig_set_wo(resource, ns, name, version string) string {


### PR DESCRIPTION
## Summary

Fixes the `Provider produced invalid plan` error that occurs on the first `terraform plan` after upgrading the provider from **v2.x to v3.x** with existing `helm_release` state (upstream [hashicorp/terraform-provider-helm#1695](https://github.com/hashicorp/terraform-provider-helm/issues/1695)).

This is an alternative to #16. Rather than making the fields `Computed` + adding static `Default`s (which traded the original error for a perpetual diff on `keyring`/`devel` and an illegal `WriteOnly`+`Computed` combo on `set_wo.type`), it follows the pattern already used by the working `description` attribute.

## Root cause

`keyring` and `devel` are optional inputs that carry `suppress*` plan modifiers writing `resp.PlanValue = req.StateValue`. Writing a value that differs from config onto a **non-computed** attribute is rejected by Terraform:

```
planned value cty.StringVal("") for a non-computed attribute        (config null, v2 state "")
planned value cty.NullVal does not match config value cty.StringVal(...)  (config set)
```

v2.x (SDKv2) stored these as empty/non-null strings, so the first v3 plan fails for every release.

## Changes

- `keyring`, `devel`: add `Computed: true` (no static `Default`) so the suppress modifier can legally carry the prior-state value forward.
- Simplify `suppressKeyring`/`suppressDevel` to fall back to prior state **only when the attribute is absent from config** (drop the `verify`/`version` conditions). This keeps the planned value known (no "unknown after apply") and respects an explicit config value.
- `set_sensitive.type`: `Computed` + default `""`, mirroring `set.type`.
- `set_wo.type`: **left unchanged** — write-only attributes cannot be `Computed`, and the field did not exist in v2.x (so it is unrelated to this bug).
- No state-upgrader change needed.

## Test plan

- New `TestAccResourceRelease_dropOptionalComputed` reproduces the upgrade scenario (state holds `keyring`/`devel`, config drops them → must plan cleanly).
- Full acceptance suite green locally (kind + Terraform 1.13.5): 60 passing, including `basic`, `set_wo`, `emptyVersion`, `dependency`, `set_list_chart`. The only local failures are the OCI-registry tests, which also fail on `main` locally (no OCI registry in the local env).